### PR TITLE
Next update

### DIFF
--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -62,9 +62,8 @@
           "name": "boost",
           "buildsystem": "simple",
           "build-commands": [
-            "./bootstrap.sh --prefix=/app",
-            "./b2 -j $FLATPAK_BUILDER_N_JOBS",
-            "./b2 install"
+            "./bootstrap.sh --prefix=/app --with-libraries=system",
+            "./b2 install variant=release link=shared runtime-link=shared cxxflags='$CXXFLAGS' linkflags='$LDFLAGS' -j $FLATPAK_BUILDER_N_JOBS"
           ],
           "cleanup": [
             "/lib/libboost_*.a"

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -306,8 +306,8 @@
             {
               "type": "git",
               "url": "https://github.com/ImageMagick/ImageMagick.git",
-              "tag": "7.0.10-28",
-              "commit": "6779a16b3d3cff3d3b78244c3ff98a3dfe3bb9b6"
+              "tag": "7.0.10-29",
+              "commit": "84a16a9da0ccee98032874201202545a23ca53b2"
             }
           ]
         },

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -556,6 +556,34 @@
                       "sha256": "956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7"
                     }
                   ]
+                },
+                {
+                  "name": "poppler",
+                  "buildsystem": "cmake-ninja",
+                  "config-opts": [
+                    "-DENABLE_LIBOPENJPEG=none",
+                    "-DENABLE_UNSTABLE_API_ABI_HEADERS=ON"
+                  ],
+                  "sources": [
+                    {
+                      "type": "archive",
+                      "url": "https://poppler.freedesktop.org/poppler-20.09.0.tar.xz",
+                      "sha256": "4ed6eb5ddc4c37f2435c9d78ff9c7c4036455aea3507d1ce8400070aab745363"
+                    }
+                  ],
+                  "modules": [
+                    {
+                      "name": "poppler-data",
+                      "buildsystem": "cmake-ninja",
+                      "sources": [
+                        {
+                          "type": "archive",
+                          "url": "https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz",
+                          "sha256": "1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -367,8 +367,8 @@
             {
               "type": "git",
               "url": "https://github.com/mdadams/jasper.git",
-              "tag": "version-2.0.19",
-              "commit": "7d8cfd8ac16d1af9b51e5ccd781e898f0fbf57cc"
+              "tag": "version-2.0.20",
+              "commit": "d10a710f31da3d079a984d35ff6cc82a853d25d7"
             }
           ]
         },

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -271,8 +271,8 @@
             },
             {
               "type": "file",
-              "url": "https://files.pythonhosted.org/packages/39/2b/0a66d5436f237aff76b91e68b4d8c041d145ad0a2cdeefe2c42f76ba2857/lxml-4.5.0.tar.gz",
-              "sha256": "8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60"
+              "url": "https://files.pythonhosted.org/packages/2c/4d/3ec1ea8512a7fbf57f02dee3035e2cce2d63d0e9c0ab8e4e376e01452597/lxml-4.5.2.tar.gz",
+              "sha256": "cdc13a1682b2a6241080745b1953719e7fe0850b40a5c71ca574f090a1391df6"
             },
             {
               "type": "file",
@@ -282,7 +282,7 @@
               "type": "git",
               "dest": "lensfun-git",
               "url": "https://github.com/lensfun/lensfun.git",
-              "commit": "a77fa3d7dbaeb82dd44bb863416c978b061b81a1"
+              "commit": "79ff00ad8c5524a0264f554e116edd79e2b241d7"
             }
           ]
         },

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -390,7 +390,7 @@
               "builddir": true,
               "config-opts": [
                 "--disable-saned",
-                "--enable-avahi",
+                "--with-avahi",
                 "--with-libcurl",
                 "--with-usb",
                 "--with-snmp",
@@ -404,8 +404,8 @@
                 {
                   "type": "git",
                   "url": "https://gitlab.com/sane-project/backends.git",
-                  "tag": "1.0.30",
-                  "commit": "d5187355f6e0de529b562569509a1851dda7ad84"
+                  "tag": "1.0.31",
+                  "commit": "871813a22db1b03adcbf4f5dc4ea9eb29f12a36d"
                 }
               ],
               "modules": [

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -225,7 +225,7 @@
             {
               "type": "git",
               "url": "https://invent.kde.org/education/marble.git",
-              "tag": "v20.08.0",
+              "tag": "v20.08.1",
               "commit": "7039b70f0255376e5d67dad603f5d67f8c3c07db"
             }
           ]

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -432,8 +432,8 @@
                   "sources": [
                     {
                       "type": "archive",
-                      "url": "https://downloads.sourceforge.net/project/net-snmp/net-snmp/5.8/net-snmp-5.8.tar.gz",
-                      "sha256": "b2fc3500840ebe532734c4786b0da4ef0a5f67e51ef4c86b3345d697e4976adf"
+                      "url": "https://downloads.sourceforge.net/project/net-snmp/net-snmp/5.9/net-snmp-5.9.tar.gz",
+                      "sha256": "04303a66f85d6d8b16d3cc53bde50428877c82ab524e17591dfceaeb94df6071"
                     },
                     {
                       "type": "shell",

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -380,7 +380,7 @@
             {
               "type": "git",
               "url": "https://invent.kde.org/graphics/libksane.git",
-              "tag": "v20.08.0",
+              "tag": "v20.08.1",
               "commit": "0238e9b8351833d4811b371c92f0f1c4567b1aa0"
             }
           ],


### PR DESCRIPTION
**Updates:**
* Marble: Updated tag
* libksane: Updated tag
* lensfun: Updated repo commit (for db)
* ImageMagisk: Updated to version 7.0.10-29
* Jasper: Updated to version 2.0.20
* Sane Backends: Updated to version 1.0.31
* net-snmp: Updated to version 5.9

**Misc:**
* Boost: Updated build commands
* Sane Backends: Updated config opts ([reason](https://gitlab.com/sane-project/backends/-/releases/1.0.31#build))