### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -1,9 +1,9 @@
 {
   "id": "org.kde.digikam",
   "base": "io.qt.qtwebengine.BaseApp",
-  "base-version": "5.15",
+  "base-version": "5.15-21.08",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15",
+  "runtime-version": "5.15-21.08",
   "sdk": "org.kde.Sdk",
   "command": "digikam",
   "finish-args": [
@@ -24,7 +24,7 @@
     "org.freedesktop.Platform.ffmpeg-full": {
       "directory": "lib/ffmpeg",
       "add-ld-path": ".",
-      "version": "20.08",
+      "version": "21.08",
       "autodownload": true,
       "autodelete": false
     }


### PR DESCRIPTION
Most kde apps already moved to new runtime therefore sharing the same base would save disk space and bandwidth for users.