### PR TITLE
Fix HEIF decoding & add BMFF support in exiv2

### DIFF
--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -715,7 +715,7 @@
           ]
         },
         {
-          "name": "heif",
+          "name": "libheif",
           "buildsystem": "cmake-ninja",
           "builddir": true,
           "cleanup": [
@@ -727,6 +727,20 @@
               "url": "https://github.com/strukturag/libheif.git",
               "tag": "v1.12.0",
               "commit": "56c8a2613370562fc330af2c70c1510aa5fd9ff6"
+            }
+          ],
+          "modules": [
+            {
+              "name": "libde265",
+              "buildsystem": "cmake-ninja",
+              "sources": [
+                {
+                  "type": "git",
+                  "url": "https://github.com/strukturag/libde265.git",
+                  "tag": "v1.0.8",
+                  "commit": "8aed7472df0af25b811828fa14f2f169dc34d35a"
+                }
+              ]
             }
           ]
         },

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -71,6 +71,10 @@
           "type": "archive",
           "url": "https://download.kde.org/stable/digikam/7.8.0/digiKam-7.8.0.tar.xz",
           "sha256": "b08577b0b15ef99843695708aa2c0e98d547303d85be2a3b39905484f2cab6ce"
+        },
+        {
+          "type": "patch",
+          "path": "patches/digikam-fix-return-from-QIODevice-seek-function.patch"
         }
       ],
       "modules": [
@@ -342,7 +346,7 @@
           ],
           "cleanup": [
             "/bin",
-            "/etc",            
+            "/etc",
             "/share/ImageMagick-*",
             "/lib/ImageMagick-*/modules-*/filters/*.la",
             "/lib/libMagick*.la"
@@ -726,8 +730,8 @@
             {
               "type": "git",
               "url": "https://github.com/strukturag/libheif.git",
-              "tag": "v1.12.0",
-              "commit": "56c8a2613370562fc330af2c70c1510aa5fd9ff6"
+              "tag": "v1.13.0",
+              "commit": "5fb52b6134d5e034b51637a86c6e8a7418b35df1"
             }
           ],
           "modules": [

--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -224,6 +224,7 @@
             "-DEXIV2_ENABLE_DYNAMIC_RUNTIME=OFF",
             "-DEXIV2_ENABLE_CURL=OFF",
             "-DEXIV2_ENABLE_SSH=OFF",
+            "-DEXIV2_ENABLE_BMFF=ON",
             "-DEXIV2_BUILD_SAMPLES=OFF",
             "-DEXIV2_BUILD_PO=OFF",
             "-DEXIV2_BUILD_EXIV2_COMMAND=OFF",

--- a/patches/digikam-fix-return-from-QIODevice-seek-function.patch
+++ b/patches/digikam-fix-return-from-QIODevice-seek-function.patch
@@ -1,0 +1,27 @@
+From 082c4c54c9a57cd3750fcd2f11f8344b19dd4f02 Mon Sep 17 00:00:00 2001
+From: Maik Qualmann <metzpinguin@gmail.com>
+Date: Sun, 4 Sep 2022 11:44:57 +0200
+Subject: [PATCH] fix return from QIODevice::seek() function The libheif
+ inverted again in bitstream.h. CCBUGS: 456688 CCBUGS: 458690
+
+---
+ core/dplugins/dimg/heif/dimgheifloader_load.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/core/dplugins/dimg/heif/dimgheifloader_load.cpp b/core/dplugins/dimg/heif/dimgheifloader_load.cpp
+index 4718f0a4db..bc8d22892d 100644
+--- a/core/dplugins/dimg/heif/dimgheifloader_load.cpp
++++ b/core/dplugins/dimg/heif/dimgheifloader_load.cpp
+@@ -72,7 +72,8 @@ static int heifQIODeviceDImgSeek(int64_t position, void* userdata)
+ {
+     QFile* const file = static_cast<QFile*>(userdata);
+ 
+-    return (int)file->seek(position);
++
++    return (int)!file->seek(position);
+ }
+ 
+ static heif_reader_grow_status heifQIODeviceDImgWait(int64_t target_size, void* userdata)
+-- 
+2.37.3
+


### PR DESCRIPTION
Partially fixes #40 issue, but AVIF decoding still fails.
Also, exiv2 now includes support for BMFF (this enables AVIF and HEIF/HEIC containers support).