### PR TITLE
Let Digikam touch everything in $HOME

### DIFF
--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -8,7 +8,7 @@
     "command": "digikam",
     "finish-args": [
         "--device=all",
-        "--filesystem=xdg-pictures",
+        "--filesystem=home",
         "--filesystem=/media",
         "--filesystem=/run/media",
         "--share=ipc",


### PR DESCRIPTION
Digikam is a photo library manager app and depends on having access to that library to function. It might be stored in `~/Pictures`, or it might not be, and from the app's perspective this is perfectly valid.

However the app is currently not packaged to have access by default to everything in the home folder. As a result, any user who stores their library outside of `~/Pictures` will have the experience of Digikam being unable to find their photo library. To fix this, they must understand technical details about how Flatpak permissions work, and how to use available tools to change those permissions.

We cannot assume that all users with a photo library stored outside of `~/Pictures` will possess that knowledge. Those who don't will instead assume that the app is broken and blame Digikam's developers, or KDE in general.

Let's give Digikam access to the whole home folder to ensure that the app can work properly.

Fixes https://github.com/flathub/org.kde.digikam/issues/3.