### PR TITLE
Temporarily disable boost updates

### DIFF
--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -103,6 +103,7 @@
                                 "type": "anitya",
                                 "project-id": 6845,
                                 "stable-only": true,
+                                "versions": {"<": "1.85.0"},
                                 "url-template": "https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
                             }
                         }


### PR DESCRIPTION
Latest version aren't compatible with hugin and they prevent anything else from update in past months wasting flathub infra.

Boost is just build dependency so for end users it isn't much relevant

@travier please reconsider this. It can be easily reverted after situation changes while current state of things  - having broken updater doesn't make sense.