### PR TITLE
Limit perl updates to patch releases only

### DIFF
--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -1078,6 +1078,9 @@
                                 "type": "anitya",
                                 "project-id": 13599,
                                 "stable-only": true,
+                                "versions": {
+                                    "<": "5.41.0"
+                                },
                                 "url-template": "https://www.cpan.org/src/${major}.0/perl-$version.tar.xz"
                             }
                         },


### PR DESCRIPTION
Main versios should match the runtime and odd versions are unstable and will break the build