### PR TITLE
Set missing `tag-template` property; Don't use FEDC for ImageMosaicWall; Fix url-template substitution for gsl

### DIFF
--- a/org.kde.digikam.json
+++ b/org.kde.digikam.json
@@ -956,7 +956,7 @@
                                 "type": "anitya",
                                 "project-id": 1267,
                                 "stable-only": true,
-                                "url-template": "https://ftp.fau.de/gnu/gsl/gsl-$verison.tar.gz"
+                                "url-template": "https://ftp.fau.de/gnu/gsl/gsl-$version.tar.gz"
                             }
                         }
                     ]


### PR DESCRIPTION
Fixes https://github.com/flathub/org.kde.digikam/issues/264